### PR TITLE
Remove whitespace

### DIFF
--- a/layouts/partials/images/image.html
+++ b/layouts/partials/images/image.html
@@ -214,11 +214,8 @@
     {{- $figureClass := default "figure" $siteParams.figure_class_name }}
     {{- $figureCaptionClass := default "figure-caption" $siteParams.figure_caption_class_name }}
     {{- $figureImgClass := default "figure-img" $siteParams.figure_image_class_name }}
-    <figure class="{{ $figureClass }} {{ $wrapperClass }}">
-      {{ partial "images/picture" (merge $ctx (dict "className" (printf "%s %s" $figureImgClass $className))) }}
-      <figcaption class="{{ $figureCaptionClass }}">{{ $caption }}</figcaption>
-    </figure>
+<figure class="{{ $figureClass }} {{ $wrapperClass }}">{{ partial "images/picture" (merge $ctx (dict "className" (printf "%s %s" $figureImgClass $className))) }}<figcaption class="{{ $figureCaptionClass }}">{{ $caption }}</figcaption></figure>
   {{- else }}
-    {{ partial "images/picture" (merge $ctx (dict "wrapperClass" $wrapperClass)) }}
+{{ partial "images/picture" (merge $ctx (dict "wrapperClass" $wrapperClass)) }}
   {{- end }}
 {{- end -}}

--- a/layouts/partials/images/picture.html
+++ b/layouts/partials/images/picture.html
@@ -1,16 +1,6 @@
 <picture{{ with .wrapperClass }} class="{{ . }}"{{ end }}>
-  {{- range .sources }}
-    <source srcset="{{ .srcset }}" type="{{ .type }}" />
-  {{- end }}
-  <img
-    class="{{ .className }}"
-    src="{{ .src }}"
-    alt="{{ .alt }}"
-    {{ if .lazyLoading }}loading="lazy"{{ end }}
-    {{ with .naturalHeight }}height="{{ . }}"{{ end }}
-    {{ with .naturalWidth }}width="{{ . }}"{{ end }}
-    {{ with .style }}{{ printf `style="%s"` (delimit . `; `) | safeHTMLAttr }}{{ end }}
-    {{ if and .original .originalSrc }}data-src="{{ .originalSrc }}"{{ end }}
-    {{ if and .original .originalWidth }}data-width="{{ .originalWidth }}"{{ end }}
-    {{ if and .original .originalHeight }}data-height="{{ .originalHeight }}"{{ end }} />
+{{- range .sources }}
+<source srcset="{{ .srcset }}" type="{{ .type }}" />
+{{- end }}
+<img class="{{ .className }}" src="{{ .src }}" alt="{{ .alt }}"{{ if .lazyLoading }} loading="lazy"{{ end }}{{ with .naturalHeight }} height="{{ . }}"{{ end }}{{ with .naturalWidth }} width="{{ . }}"{{ end }}{{ with .style }}{{ printf ` style="%s"` (delimit . `; `) | safeHTMLAttr }}{{ end }}{{ if and .original .originalSrc }} data-src="{{ .originalSrc }}"{{ end }}{{ if and .original .originalWidth }} data-width="{{ .originalWidth }}"{{ end }}{{ if and .original .originalHeight }} data-height="{{ .originalHeight }}"{{ end }} />
 </picture>


### PR DESCRIPTION
If shortcode contains whitespace in front of the part where be rendered as HTML, it will cause those codes to be rendered as code block, resulting improperly render result.

So I removed all whitespace for those parts.

Unfortunately, this will make code *ugly*.

<details>
<summary>Image comparison</summary>

Rendered result without this change:  
![1](https://github.com/hugomods/images/assets/37061801/3292c2f3-7c35-4fb4-a61d-5ac1a4e331b7)

Rendered result with this change:
![2](https://github.com/hugomods/images/assets/37061801/80e76f10-ceac-4153-aa8a-c9bd3a075ec4)

The only difference is `image.html` and `picture.html`.

</details>